### PR TITLE
Update ruby version from ruby:2.7.1-alpine3.11 to ruby:3.0.4-alpine3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ruby:2.7.1-alpine3.11
+FROM ruby:3.0.4-alpine3.16
 
-MAINTAINER Michael Karlesky <michael@karlesky.net>
-
+RUN apk update \
+    apk upgrade
 
 RUN apk --no-cache add \
   coreutils \


### PR DESCRIPTION
Also updated gcc version from 9.2.0 to 11.2.1 to get rid of the
compiling error for va_list